### PR TITLE
change namespace, defaults, fix low bit depth processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Continuity Fixer port for Vapoursynth, ![original code](https://github.com/sekri
 
 # Usage
 
-	edgefixer.ContinuityFixer(src, left, top, right, bottom, radius)
+	cf.ContinuityFixer(src, left, top, right, bottom, radius)
 
-src, left, top, right, bottom are mandatory.  
+src, is mandatory. left, top, right, and bottom are optional and default to zero.  
 radius is optional, it default to the shortest dimension of the clip [usually the height].  
 
 
@@ -13,7 +13,7 @@ Since V6 the plugin can repair all the planes in a single call [for a maximum of
 
 	#repair two left row on the luma plane and one left row on the chroma planes with a radius of 10 for the luma plane and 5 for the chroma planes
 	
-	fix = core.edgefixer.ContinuityFixer(src, [2,1,1], [0,0,0], [0,0,0], [0,0,0], [10,5,5])
+	fix = core.cf.ContinuityFixer(src, [2,1,1], [0,0,0], [0,0,0], [0,0,0], [10,5,5])
 
 # Known issues
 <del>For large repair value [the four sides] the plugin create strange artifact and is not pixel exact to the avs version, i don't know what cause this but for sane values [less then 10 pixel, maybe more] the output is the same as the avs version.</del> Fixed in V5
@@ -22,6 +22,9 @@ Since V6 the plugin can repair all the planes in a single call [for a maximum of
 
 	g++ -c continuity.cpp -O2 -msse2 -mfpmath=sse -o continuity.o
 	g++ -shared -Wl,--dll,--add-stdcall-alias -o continuity.dll continuity.o
-
+```sh
+$ g++ -c -std=gnu++11 -fPIC -I. -o continuity.o continuity.cpp
+$ g++ -shared -fPIC -o libcf.so continuity.o
+```
 # Thanks
 Mirkosp, JEEB, HolyWu, jackoneill and Myrsloik

--- a/continuity.cpp
+++ b/continuity.cpp
@@ -1,15 +1,22 @@
-#include <stdlib.h>
 #include "VapourSynth.h"
 #include "VSHelper.h"
-#include <stdint.h>
 
-typedef struct least_squares_data
-{
-    int64_t integral_x;
-    int64_t integral_y;
-    int64_t integral_xy;
-    int64_t integral_xsqr;
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+typedef struct least_squares_data {
+	int32_t integral_x;
+	int32_t integral_y;
+	int32_t integral_xy;
+	int32_t integral_xsqr;
 } least_squares_data;
+
+typedef struct least_squares_data64 {
+	int64_t integral_x;
+	int64_t integral_y;
+	int64_t integral_xy;
+	int64_t integral_xsqr;
+} least_squares_data64;
 
 typedef struct
 {
@@ -24,84 +31,137 @@ typedef struct
     int radius[3];
 } ContinuityData;
 
-void least_squares(int n, least_squares_data *d, double *a, double *b)
+static void least_squares(int n, least_squares_data* d, float* a, float* b)
 {
-    double interval_x = (double) (d[n - 1].integral_x - d[0].integral_x);
-    double interval_y = (double) (d[n - 1].integral_y - d[0].integral_y);
-    double interval_xy = (double) (d[n - 1].integral_xy - d[0].integral_xy);
-    double interval_xsqr = (double) (d[n - 1].integral_xsqr - d[0].integral_xsqr);
+	float interval_x = (float)(d[n - 1].integral_x - d[0].integral_x);
+	float interval_y = (float)(d[n - 1].integral_y - d[0].integral_y);
+	float interval_xy = (float)(d[n - 1].integral_xy - d[0].integral_xy);
+	float interval_xsqr = (float)(d[n - 1].integral_xsqr - d[0].integral_xsqr);
 
-
-    // add 0.001f to denominator to prevent division by zero
-    *a = ((double) n * interval_xy - interval_x * interval_y) / ((interval_xsqr * (double) n - interval_x * interval_x) + 0.001f);
-    *b = (interval_y - *a * interval_x) / (double) n;
+	/* Add 0.001f to denominator to prevent division by zero. */
+	*a = ((float)n * interval_xy - interval_x * interval_y) / ((interval_xsqr * (float)n - interval_x * interval_x) + 0.001f);
+	*b = (interval_y - *a * interval_x) / (float)n;
 }
 
-size_t required_buffer(int n)
+static void least_squares64(int n, least_squares_data64* d, double* a, double* b)
 {
-    return n * sizeof(least_squares_data);
+	double interval_x = (double)(d[n - 1].integral_x - d[0].integral_x);
+	double interval_y = (double)(d[n - 1].integral_y - d[0].integral_y);
+	double interval_xy = (double)(d[n - 1].integral_xy - d[0].integral_xy);
+	double interval_xsqr = (double)(d[n - 1].integral_xsqr - d[0].integral_xsqr);
+
+	/* Add 0.001f to denominator to prevent division by zero. */
+	*a = ((double)n * interval_xy - interval_x * interval_y) / ((interval_xsqr * (double)n - interval_x * interval_x) + 0.001f);
+	*b = (interval_y - *a * interval_x) / (double)n;
 }
 
-typedef void (*process_function)(uint8_t *x8, const uint8_t *y8, int x_dist_to_next, int y_dist_to_next, int n, int radius, least_squares_data *buf, int bitsPerSample);
-
-template <typename pixel_t>
-void process_edge(uint8_t *x8, const uint8_t *y8, int x_dist_to_next, int y_dist_to_next, int n, int radius, least_squares_data *buf, int bitsPerSample)
+static uint8_t float_to_u8(float x)
 {
-    int i;
-    double a, b;
-	
-	pixel_t *x = (pixel_t *)x8;
-	const pixel_t *y = (const pixel_t *)y8;
-	
-	x_dist_to_next /= sizeof(pixel_t);
-	y_dist_to_next /= sizeof(pixel_t);
-	
-    buf[0].integral_x = x[0];
-    buf[0].integral_y = y[0];
-    buf[0].integral_xy = x[0] * y[0];
-    buf[0].integral_xsqr = x[0] * x[0];
+	return (uint8_t)lrintf(MIN(MAX(x, 0), UINT8_MAX));
+}
 
-    for (i = 1; i < n; ++i)
-    {
-        int64_t _x = x[i * x_dist_to_next];
-        int64_t _y = y[i * y_dist_to_next];
-        buf[i].integral_x = buf[i - 1].integral_x + _x;
-        buf[i].integral_y = buf[i - 1].integral_y + _y;
-        buf[i].integral_xy = buf[i - 1].integral_xy + _x * _y;
-        buf[i].integral_xsqr = buf[i - 1].integral_xsqr + _x * _x;
-    }
-    if (radius)
-    {
-        for (i = 0; i < n; ++i)
-        {
-            int left = i - radius;
-            int right = i + radius;
-            if (left < 0)
-                left = 0;
-            if (right > n - 1)
-                right = n - 1;
-            least_squares(right - left + 1, buf + left, &a, &b);
-			
-			//Saturate the pixel value
-			double test = (x[i * x_dist_to_next] * a + b);
-			if(test >= (1 << bitsPerSample))
-				test = (1 << bitsPerSample) - 1;
-            x[i * x_dist_to_next] = (pixel_t) test;
-        }
-    }
-    else
-    {
-        least_squares(n, buf, &a, &b);
-		
-        for (i = 0; i < n; ++i)
-		{
-			//Saturate the pixel value
-			double test = (x[i * x_dist_to_next] * a + b);
-			if(test >= (1 << bitsPerSample))
-				test = (1 << bitsPerSample) - 1;
-            x[i * x_dist_to_next] = (pixel_t)test;
+static uint16_t double_to_u16(double x)
+{
+	return (uint16_t)lrint(MIN(MAX(x, 0), UINT16_MAX));
+}
+
+static size_t edgefixer_required_buffer_b(int n)
+{
+	return n * sizeof(least_squares_data);
+}
+
+static size_t edgefixer_required_buffer_w(int n)
+{
+	return n * sizeof(least_squares_data64);
+}
+static void edgefixer_process_edge_b(void* xptr, const void* yptr, int x_dist_to_next, int y_dist_to_next, int n, int radius, void* tmp)
+{
+	uint8_t* x = reinterpret_cast<uint8_t*>(xptr);
+	const uint8_t* y = reinterpret_cast<const uint8_t*>(yptr);
+
+	least_squares_data* buf = (least_squares_data*)tmp;
+	float a, b;
+	int i;
+
+	buf[0].integral_x = x[0];
+	buf[0].integral_y = y[0];
+	buf[0].integral_xy = x[0] * y[0];
+	buf[0].integral_xsqr = x[0] * x[0];
+
+	for (i = 1; i < n; ++i) {
+		uint16_t _x = x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint8_t)];
+		uint16_t _y = y[static_cast<int64_t>(i) * y_dist_to_next / sizeof(uint8_t)];
+
+		buf[i].integral_x = buf[i - 1].integral_x + _x;
+		buf[i].integral_y = buf[i - 1].integral_y + _y;
+		buf[i].integral_xy = buf[i - 1].integral_xy + _x * _y;
+		buf[i].integral_xsqr = buf[i - 1].integral_xsqr + _x * _x;
+	}
+
+	if (radius) {
+		for (i = 0; i < n; ++i) {
+			int left = i - radius;
+			int right = i + radius;
+
+			if (left < 0)
+				left = 0;
+			if (right > n - 1)
+				right = n - 1;
+			least_squares(right - left + 1, buf + left, &a, &b);
+			x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint8_t)] = float_to_u8(x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint8_t)] * a + b);
 		}
-    }
+	}
+	else {
+		least_squares(n, buf, &a, &b);
+		for (i = 0; i < n; ++i) {
+			x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint8_t)] = float_to_u8(x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint8_t)] * a + b);
+		}
+	}
+}
+
+static void edgefixer_process_edge_w(void* xptr, const void* yptr, int x_dist_to_next, int y_dist_to_next, int n, int radius, void* tmp)
+{
+	uint16_t* x = reinterpret_cast<uint16_t*>(xptr);
+	const uint16_t* y = reinterpret_cast<const uint16_t*>(yptr);
+
+	least_squares_data64* buf = (least_squares_data64*)tmp;
+	double a, b;
+	int i;
+
+	buf[0].integral_x = x[0];
+	buf[0].integral_y = y[0];
+	buf[0].integral_xy = (long long)x[0] * y[0];
+	buf[0].integral_xsqr = (long long)x[0] * x[0];
+
+	for (i = 1; i < n; ++i) {
+		uint32_t _x = x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint16_t)];
+		uint32_t _y = y[static_cast<int64_t>(i) * y_dist_to_next / sizeof(uint16_t)];
+
+		buf[i].integral_x = buf[i - 1].integral_x + _x;
+		buf[i].integral_y = buf[i - 1].integral_y + _y;
+		buf[i].integral_xy = buf[i - 1].integral_xy + static_cast<int64_t>(_x) * _y;
+		buf[i].integral_xsqr = buf[i - 1].integral_xsqr + static_cast<int64_t>(_x) * _x;
+	}
+
+	if (radius) {
+		for (i = 0; i < n; ++i) {
+			int left = i - radius;
+			int right = i + radius;
+
+			if (left < 0)
+				left = 0;
+			if (right > n - 1)
+				right = n - 1;
+			least_squares64(right - left + 1, buf + left, &a, &b);
+			x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint16_t)] = double_to_u16(x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint16_t)] * a + b);
+		}
+	}
+	else {
+		least_squares64(n, buf, &a, &b);
+		for (i = 0; i < n; ++i) {
+			x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint16_t)] = double_to_u16(x[static_cast<int64_t>(i) * x_dist_to_next / sizeof(uint16_t)] * a + b);
+		}
+	}
 }
 
 static void VS_CC continuityInit(VSMap *in, VSMap *out, void **instanceData, VSNode *node, VSCore *core, const VSAPI *vsapi)
@@ -123,25 +183,20 @@ static const VSFrameRef  *VS_CC continuityGetFrame(int n, int activationReason, 
         const VSFrameRef *src = vsapi->getFrameFilter(n, d->node, frameCtx);
 		VSFrameRef *dst = vsapi->copyFrame(src, core);
 		
+		size_t(*required_buffer)(int) = d->vi->format->bytesPerSample == 2 ? edgefixer_required_buffer_w : edgefixer_required_buffer_b;
+		void (*process_edge)(void*, const void*, int, int, int, int, void*) = d->vi->format->bytesPerSample == 2 ? edgefixer_process_edge_w : edgefixer_process_edge_b;
+		
 		int h = vsapi->getFrameHeight(src, 0);
 		int w = vsapi->getFrameWidth(src, 0);
-		
-		least_squares_data *buf = (least_squares_data*) malloc(required_buffer(w > h ? w : h));
-		
-		int bitsPerSample = vsapi->getFrameFormat(src)->bitsPerSample;
-		
-		int bytesPerSample = vsapi->getFrameFormat(src)->bytesPerSample;
-		process_function proc;
-		if (bytesPerSample == 1)
-			proc = process_edge<uint8_t>;
-		else
-			proc = process_edge<uint16_t>;
-		
+
+		void* tmp = malloc(required_buffer(w > h ? w : h));
+
 		for(int j = 0; j < d->vi->format->numPlanes; ++j)
 		{
 			int height = vsapi->getFrameHeight(src, j);
 			int width = vsapi->getFrameWidth(src, j);
 			int stride = vsapi->getStride(src, j);
+			int step = d->vi->format->bytesPerSample;
 			
 			uint8_t *dest = vsapi->getWritePtr(dst, j);
 
@@ -150,32 +205,32 @@ static const VSFrameRef  *VS_CC continuityGetFrame(int n, int activationReason, 
 			for (i = 0; i < d->top[j]; ++i)
 			{
 				int ref_row = d->top[j] - i;
-				proc(dest + stride * (ref_row - 1), dest + stride * ref_row, bytesPerSample, bytesPerSample, width, d->radius[j], buf, bitsPerSample);
+				process_edge(dest + stride * (ref_row - static_cast<int64_t>(1)), dest + static_cast<int64_t>(stride) * ref_row, step, step, width, d->radius[j], tmp);
 			}
 
 			// bottom
 			for (i = 0; i < d->bottom[j]; ++i)
 			{
 				int ref_row = height - d->bottom[j] - 1 + i;
-				proc(dest + stride * (ref_row + 1), dest + stride * ref_row, bytesPerSample, bytesPerSample, width, d->radius[j], buf, bitsPerSample);
+				process_edge(dest + stride * (ref_row + static_cast<int64_t>(1)), dest + static_cast<int64_t>(stride) * ref_row, step, step, width, d->radius[j], tmp);
 			}
 
 			// left
 			for (i = 0; i < d->left[j]; ++i)
 			{
 				int ref_col = d->left[j] - i;
-				proc(dest + (ref_col - 1) * bytesPerSample, dest + ref_col * bytesPerSample, stride, stride, height, d->radius[j], buf, bitsPerSample);
+				process_edge(dest + (ref_col - static_cast<int64_t>(1)) * step, dest + ref_col * static_cast<int64_t>(step), stride, stride, height, d->radius[j], tmp);
 			}
 
 			// right
 			for (i = 0; i < d->right[j]; ++i)
 			{
 				int ref_col = width - d->right[j] - 1 + i;
-				proc(dest + (ref_col + 1) * bytesPerSample, dest + ref_col * bytesPerSample, stride, stride, height, d->radius[j], buf, bitsPerSample);
+				process_edge(dest + (ref_col + static_cast<int64_t>(1)) * step, dest + ref_col * static_cast<int64_t>(step), stride, stride, height, d->radius[j], tmp);
 			}
 		}
         
-        free(buf);
+        free(tmp);
         vsapi->freeFrame(src);
 
         return dst;
@@ -255,9 +310,17 @@ static void VS_CC  continuityCreate(const VSMap *in, VSMap *out, void *userData,
 	for (int i = 0; i < nPlanes; ++i)
     {
 		d.left[i] = vsapi->propGetInt(in, "left", i, &err);
+		if (err)
+			d.left[i] = 0;
 		d.top[i] = vsapi->propGetInt(in, "top", i, &err);
+		if (err)
+			d.top[i] = 0;
 		d.right[i] = vsapi->propGetInt(in, "right", i, &err);
+		if (err)
+			d.right[i] = 0;
 		d.bottom[i] = vsapi->propGetInt(in, "bottom", i, &err);
+		if (err)
+			d.bottom[i] = 0;
 	}
 	
 	for (int i = 0; i < nPlanes; ++i)
@@ -285,12 +348,12 @@ static void VS_CC  continuityCreate(const VSMap *in, VSMap *out, void *userData,
 
 VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegisterFunction registerFunc, VSPlugin *plugin)
 {
-    configFunc("com.monos.edgefixer", "edgefixer", "VapourSynth edgefixer port", VAPOURSYNTH_API_VERSION, 1, plugin);
+    configFunc("com.monos.continuityfixer", "cf", "VapourSynth ContinuityFixer port", VAPOURSYNTH_API_VERSION, 1, plugin);
     registerFunc("ContinuityFixer", "clip:clip;"
-	                                "left:int[];"
-									"top:int[];"
-									"right:int[];"
-									"bottom:int[];"
+	                                "left:int[]:opt;"
+									"top:int[]:opt;"
+									"right:int[]:opt;"
+									"bottom:int[]:opt;"
 									"radius:int[]:opt;",
 									continuityCreate, 0, plugin);
 }


### PR DESCRIPTION
Changes:
* Namespace changed from `edgefixer` to `cf` to prevent collision with original repo.
* Defaults set to 0 for left, right, top, and bottom.
* Results from low bit depth processing now closer resemble those from high bit depth processing.